### PR TITLE
Recalculate after converge, also resolve tolerance bug (need fabs)

### DIFF
--- a/main.c
+++ b/main.c
@@ -31,7 +31,7 @@ K vinc(K latpk, K longpk, K latck, K longck) {
     tol = pow(10., -12.); // iteration tolerance
     diff = 1.;
 
-    while (abs(diff) > tol) {
+    while (fabs(diff) > tol) {
         sin_sigma = sqrt(pow((cos(u2) * sin(lam)), 2.) + pow(cos(u1)*sin(u2) - sin(u1)*cos(u2)*cos(lam), 2.));
         cos_sigma = sin(u1) * sin(u2) + cos(u1) * cos(u2) * cos(lam);
         sigma = atan(sin_sigma / cos_sigma);
@@ -42,8 +42,16 @@ K vinc(K latpk, K longpk, K latck, K longck) {
         C = (flat / 16) * cos_sq_alpha * (4 + flat * (4 - 3 * cos_sq_alpha));
         lam_pre = lam;
         lam = lon + (1 - C) * flat * sin_alpha * (sigma + C * sin_sigma * (cos2sigma + C * cos_sigma * (2 * pow(cos2sigma, 2.) - 1)));
-        diff = abs(lam_pre - lam);
+        diff = fabs(lam_pre - lam);
     }
+    
+    sin_sigma = sqrt(pow((cos(u2) * sin(lam)), 2.) + pow(cos(u1)*sin(u2) - sin(u1)*cos(u2)*cos(lam), 2.));
+    cos_sigma = sin(u1) * sin(u2) + cos(u1) * cos(u2) * cos(lam);
+    sigma = atan(sin_sigma / cos_sigma);
+    if (sigma <= 0) sigma = M_PI + sigma;
+    sin_alpha = (cos(u1) * cos(u2) * sin(lam)) / sin_sigma;
+    cos_sq_alpha = 1 - pow(sin_alpha, 2.);
+    cos2sigma = cos_sigma - ((2 * sin(u1) * sin(u2)) / cos_sq_alpha);
 
     usq = cos_sq_alpha * ((pow(req, 2.) - pow(rpol, 2.)) / pow(rpol ,2.));
     A = 1 + (usq / 16384) * (4096 + usq * (-768 + usq * (320 - 175 * usq)));


### PR DESCRIPTION
Resolves 2 issues;

1. We need to recalculate the sin/cos etc after lambda within the loop has been calculated to get the correct result. For example, without the code below we see
```
q)%[;1000]vinc[-33.8559799094;151.20666584;54.59682;-5.92541][0]
17086.4
```

After:
```
q)%[;1000]vinc[-33.8559799094;151.20666584;54.59682;-5.92541][0]
17096.78
```

2. C abs is type int, which drops accuracy (and thus iterations). In addition the fix in 1., this fix gives us:
```
q)%[;1000]vinc[-33.8559799094;151.20666584;54.59682;-5.92541][0]
17096.72
```

See here for confirmation: https://geodesyapps.ga.gov.au/vincenty-inverse
![image](https://github.com/rianoc/qvincentys/assets/24537293/eae499eb-eac6-4f4c-bdc2-93d556d7cf05)